### PR TITLE
BUGFIX: Login sessions auto-login without userId with a refresh after logging out - FIXED

### DIFF
--- a/frontend/src/components/Navigation/ProfileButton.jsx
+++ b/frontend/src/components/Navigation/ProfileButton.jsx
@@ -39,7 +39,7 @@ function ProfileButton() {
     e.preventDefault();
     dispatch(thunkLogout());
     closeMenu();
-    nav("/weights")
+    nav("/")
   };
 
   return (

--- a/frontend/src/components/Splash/Splash.jsx
+++ b/frontend/src/components/Splash/Splash.jsx
@@ -61,6 +61,8 @@ const Splash = () => {
   return (
     <div>
       <h1>Welcome</h1>
+      <h2>SessionUser is null = {sessionUser === null ? "TRUE" : "FALSE"}</h2>
+
       <form onSubmit={handleSubmit}>
         <div>
           {/* FALSE to avoid AWS for now */}

--- a/frontend/src/redux/session.js
+++ b/frontend/src/redux/session.js
@@ -122,7 +122,9 @@ function sessionReducer(state = initialState, action) {
         case SET_USER:
             return { ...state, user: action.payload };
         case REMOVE_USER:
-            return { ...state, user: null };
+            console.log("=======> Removing user: setting user to null")
+            // return { ...state, user: null };
+            return { user: null };
         case EDIT_USER:
             return { ...state, user: action.payload };
         default:

--- a/frontend/src/redux/session.js
+++ b/frontend/src/redux/session.js
@@ -3,7 +3,6 @@ import { csrfFetch } from './csrf';
 //Constants
 const SET_USER = 'session/setUser';
 const REMOVE_USER = 'session/removeUser';
-const EDIT_USER = "session/editUser";
 
 const setUser = (user) => ({
     type: SET_USER,
@@ -13,13 +12,6 @@ const setUser = (user) => ({
 const removeUser = () => ({
     type: REMOVE_USER
 });
-
-const editUser = (user) => {
-    return {
-        type: SET_USER,
-        payload: user
-    }
-}
 
 
 
@@ -120,13 +112,14 @@ const initialState = { user: null };
 function sessionReducer(state = initialState, action) {
     switch (action.type) {
         case SET_USER:
+            if (action.payload && Object.keys(action.payload).length === 0) {
+                return { user: null };
+            }
             return { ...state, user: action.payload };
         case REMOVE_USER:
             console.log("=======> Removing user: setting user to null")
             // return { ...state, user: null };
             return { user: null };
-        case EDIT_USER:
-            return { ...state, user: action.payload };
         default:
             return state;
     }


### PR DESCRIPTION
## BUGFIX: 
### Login sessions auto-login without userId with a refresh after logging out - FIXED
- Problem was that refresh would cause React to give User an empty object when it can't access store.User.  
  -  {user: NULL} <--- only state that is "logged out"
     - {user: {} } <--- logged in even if there is no UserId on from Session Store
     
#### Solution:
- Session store returns null when payload is an empty object.
- So this does not resolve why {user: {} } was originally created.

